### PR TITLE
Input and output changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ To add the command check to your Icinga2 installation, first add the following c
          required = true
          value = "$zone$"
          }
-       "-w" = "$dnssec_warn$"    // Default = 20%
-       "-c" = "$dnssec_crit$"    // Default = 10%
+       "-w" = "$dnssec_warn$"    // Default = 10d
+       "-c" = "$dnssec_crit$"    // Default = 5d
        "-r" = "$resolver$"       // Default = 8.8.8.8
        "-f" = "$failing$"        // Sets the always failing domain (to verify function of resolver). Default = dnssec-failed.org
       }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ It covers the following cases:
 - Unsigned zones: will emit a WARNING, as we expect this check to only be actively executed against DNSSEC enabled/signed zones
 - Broken signature: will emit a CRITICAL, independent of whether the zone could be resolvable on a resolver without DNSSEC validation
 - Expiry date of the RRSIG answer: the remaining lifetime is calculated and depending on the remaining % of the total lifetime, an alert can be generated
-  - emits a CRITICAL if the remaining percentage is < 10%
-  - emits a WARNING if the remaining percentage is < 20%
+  - emits a CRITICAL if the remaining time is lower than `-w`
+  - emits a WARNING if the remaining time is lower than `-c`
   - emits an OK if none of the above match
 - If there are multiple RRSIG entries with overlapping validity time-frames, we're fine, if at least one of them fulfills the minimum remaining lifetime check
 - is configurable via command line options, see table below
@@ -66,8 +66,8 @@ To add the command check to your Icinga2 installation, first add the following c
          required = true
          value = "$zone$"
          }
-       "-w" = "$dnssec_warn$"    // Default = 20
-       "-c" = "$dnssec_crit$"    // Default = 10
+       "-w" = "$dnssec_warn$"    // Default = 20%
+       "-c" = "$dnssec_crit$"    // Default = 10%
        "-r" = "$resolver$"       // Default = 8.8.8.8
        "-f" = "$failing$"        // Sets the always failing domain (to verify function of resolver). Default = dnssec-failed.org
       }
@@ -137,8 +137,8 @@ The script can also be used as-is as a data source for a Zabbix server external 
 | --- | --- | --- | --- |
 | -h | Renders the help / usage information | no | n/a |
 | -z | Sets the zone to validate, e.g. "example.org" | yes | n/a |
-| -w | Sets the warning percentage value regarding the remainig lifetime of the signature | no | 20 |
-| -c | Sets the critical percentage value regarding the remainig lifetime of the signature | no | 10 |
+| -w | Sets the warning percentage value regarding the remainig lifetime of the signature in percent (%), days (d), hours (h), minutes (m) or seconds (s) | no | 10d |
+| -c | Sets the critical percentage value regarding the remainig lifetime of the signature in percent (%), days (d), hours (h), minutes (m) or seconds (s) | no | 5d |
 | -r | Sets the resolver to use | no | 8.8.8.8 |
 | -f | Sets the always failing domain (used to verify the proper function of the resolving server | no | dnssec-failed.org |
 | -t | Sets the DNS record type to validate, e.g. "A" | no | SOA |
@@ -164,6 +164,7 @@ Thanks for your support! (in chronological order)
 - Warren Kumari
 - Rob J. Epping
 - Thushjandan Ponnudurai
+- Fabian Fröhlich [f-froehlich.de](https://f-froehlich.de/)
 
 ## License
 

--- a/check_dnssec_expiry.sh
+++ b/check_dnssec_expiry.sh
@@ -100,10 +100,10 @@ fi
 
 # Check if we got warning/critical percentage values, use defaults if not
 if [[ -z $warning ]]; then
-	warning=20
+	warning="10d"
 fi
 if [[ -z $critical ]]; then
-	critical=10
+	critical="5d"
 fi
 
 # formatting to seconds

--- a/check_dnssec_expiry.sh
+++ b/check_dnssec_expiry.sh
@@ -217,6 +217,9 @@ else
 	done <<< "$rrsigEntries"
 fi
 
+expire_at=$(date -u +"%s")
+expire_at=$(($expire_at+maxRemainingLifetime))
+expire_at_string=$(date -u -d @${expire_at} +"%c")
 remaining_day_string=$(calculate_remaining_time_string $maxRemainingLifetime)
 
 # determine if we need to alert, and if so, how loud to cry, depending on warning/critial threshholds provided

--- a/check_dnssec_expiry.sh
+++ b/check_dnssec_expiry.sh
@@ -17,9 +17,9 @@ usage $0 -z <zone> [-w <warning %>] [-c <critical %>] [-r <resolver>] [-f <alway
 
 	-z <zone>
 		specify zone to check
-	-w <warning %> | <warning d> | <warning h> | <warning m> | <warning s>
+	-w <warning [%]> | <warning d> | <warning h> | <warning m> | <warning s>
 		warning time left percentage or days or hours or minutes or seconds
-	-c <critical %> | <critical d> | <critical h> | <critical m> | <critical s>
+	-c <critical [%]> | <critical d> | <critical h> | <critical m> | <critical s>
 		critical time left percentage or days or hours or minutes or seconds
 	-r <resolver>
 		specify which resolver to use.

--- a/check_dnssec_expiry.sh
+++ b/check_dnssec_expiry.sh
@@ -17,10 +17,10 @@ usage $0 -z <zone> [-w <warning %>] [-c <critical %>] [-r <resolver>] [-f <alway
 
 	-z <zone>
 		specify zone to check
-	-w <critical %>
-		warning time left percentage
-	-c <critical %>
-		critical time left percentage
+	-w <warning %> | <warning d> | <warning h> | <warning m> | <warning s>
+		warning time left percentage or days or hours or minutes or seconds
+	-c <critical %> | <critical d> | <critical h> | <critical m> | <critical s>
+		critical time left percentage or days or hours or minutes or seconds
 	-r <resolver>
 		specify which resolver to use.
 	-f <always failing domain>
@@ -59,6 +59,30 @@ while getopts ":z:w:c:r:f:h:t:" opt; do
   esac
 done
 
+# calculate seconds out of time string
+calculate_time() {
+    raw_time=$1
+    remaining_time=0
+    if [[ "$raw_time" == *"d" ]]; then
+      remaining_time=$(echo $raw_time | sed -e "s/d//g")
+      remaining_time=$(($remaining_time*24*60*60))
+    elif [[ "$raw_time" == *"h" ]]; then
+      remaining_time=$(echo $raw_time | sed -e "s/h//g")
+      remaining_time=$(($remaining_time*60*60))
+    elif [[ "$raw_time" == *"m" ]]; then
+      remaining_time=$(echo $raw_time | sed -e "s/m//g")
+      remaining_time=$(($remaining_time*60))
+    elif [[ "$raw_time" == *"s" ]]; then
+      remaining_time=$(echo $raw_time | sed -e "s/s//g")
+    elif [[ "$raw_time" == *['!'%] ]]; then
+      remaining_time=$(echo "$raw_time" | sed -e "s/\%//g")
+      remaining_time=$(($remaining_time*30/100*24*60*60))
+    else
+      remaining_time=$(($raw_time*30/100*24*60*60))
+    fi
+
+    echo $remaining_time
+}
 
 # Check if dig is available at all - fail hard if not
 pathToDig=$( which dig )
@@ -82,6 +106,9 @@ if [[ -z $critical ]]; then
 	critical=10
 fi
 
+# formatting to seconds
+warning=$(calculate_time $warning)
+critical=$(calculate_time $critical)
 
 # Use Google's 8.8.8.8 resolver as fallback if none is provided
 if [[ -z $resolver ]]; then
@@ -179,17 +206,19 @@ else
 	done <<< "$rrsigEntries"
 fi
 
-
-
+expire_at=$(date -u +"%s")
+expire_at=$(($expire_at+maxRemainingLifetime))
+expire_at_string=$(date -u -d @${expire_at} +"%c")
+remaining_day_string=$(date -u -d @${maxRemainingLifetime} +"%dd %Hh %Mm %Ss")
 
 # determine if we need to alert, and if so, how loud to cry, depending on warning/critial threshholds provided
-if [[ $maxRemainingPercentage -lt $critical ]]; then
-	echo "CRITICAL: DNSSEC signature for $zone is very short before expiration! ($maxRemainingPercentage% remaining) | sig_lifetime=$maxRemainingLifetime  sig_lifetime_percentage=$remainingPercentage%;$warning;$critical"
+if [[ $maxRemainingLifetime -lt $critical ]]; then
+	echo "CRITICAL: DNSSEC signature for $zone is very short before expiration! ($remaining_day_string / $maxRemainingPercentage% remaining; expire at $expire_at_string) | sig_lifetime=$maxRemainingLifetime  sig_lifetime_percentage=$remainingPercentage%;$warning;$critical"
 	exit 2
-elif [[ $remainingPercentage -lt $warning ]]; then
-	echo "WARNING: DNSSEC signature for $zone is short before expiration! ($maxRemainingPercentage% remaining) | sig_lifetime=$maxRemainingLifetime  sig_lifetime_percentage=$remainingPercentage%;$warning;$critical"
+elif [[ $maxRemainingLifetime -lt $warning ]]; then
+	echo "WARNING: DNSSEC signature for $zone is short before expiration! ($remaining_day_string / $maxRemainingPercentage% remaining; expire at $expire_at_string) | sig_lifetime=$maxRemainingLifetime  sig_lifetime_percentage=$remainingPercentage%;$warning;$critical"
 	exit 1
 else
-	echo "OK: DNSSEC signatures for $zone seem to be valid and not expired ($maxRemainingPercentage% remaining) | sig_lifetime=$maxRemainingLifetime  sig_lifetime_percentage=$remainingPercentage%;$warning;$critical"
+	echo "OK: DNSSEC signatures for $zone seem to be valid and not expired ($remaining_day_string / $maxRemainingPercentage% remaining; expire at $expire_at_string) | sig_lifetime=$maxRemainingLifetime  sig_lifetime_percentage=$remainingPercentage%;$warning;$critical"
 	exit 0
 fi

--- a/check_dnssec_expiry.sh
+++ b/check_dnssec_expiry.sh
@@ -83,6 +83,17 @@ calculate_time() {
 
     echo $remaining_time
 }
+# calculate seconds out of time string
+calculate_remaining_time_string() {
+    total_time=$1
+    seconds=$(($total_time % 60))
+    total_time=$((($total_time - $seconds) / 60))
+    minutes=$(($total_time % 60))
+    total_time=$((($total_time - $minutes) / 60))
+    hours=$(($total_time % 24))
+    days=$((($total_time - $hours) / 24))
+    echo "${days}d ${hours}h ${minutes}m ${seconds}s"
+}
 
 # Check if dig is available at all - fail hard if not
 pathToDig=$( which dig )
@@ -206,10 +217,7 @@ else
 	done <<< "$rrsigEntries"
 fi
 
-expire_at=$(date -u +"%s")
-expire_at=$(($expire_at+maxRemainingLifetime))
-expire_at_string=$(date -u -d @${expire_at} +"%c")
-remaining_day_string=$(date -u -d @${maxRemainingLifetime} +"%dd %Hh %Mm %Ss")
+remaining_day_string=$(calculate_remaining_time_string $maxRemainingLifetime)
 
 # determine if we need to alert, and if so, how loud to cry, depending on warning/critial threshholds provided
 if [[ $maxRemainingLifetime -lt $critical ]]; then


### PR DESCRIPTION
Now you can specify time units (days (d), hours (h), minutes (m), seconds (s), percent (%)) for warning and critical bounds. If no unit is given default unit is percent due compatibility reasons.
Changing default values to 10d (warning) and 5d (critical).
Output remaining time in human readable format (d h m s) and percentage
Output expiring at time in human readable format e.g.
`WARNING: DNSSEC signature for [DOMAIN] is short before expiration! (8d 11h 7m 40s / 28% remaining; expire at So 23 Aug 2020 18:55:00 UTC) | sig_lifetime=731260  sig_lifetime_percentage=28%;864000;432000`